### PR TITLE
Add SAP System-level Function Support with Asynchronous Status Tracking

### DIFF
--- a/roles/sap_control/README.md
+++ b/roles/sap_control/README.md
@@ -7,6 +7,7 @@ This Ansible Role executes basic SAP administration tasks on Linux operating sys
 This Ansible Role executes basic SAP administration tasks on Linux operating systems, including:
 - Start/Stop/Restart of SAP HANA Database Server
 - Start/Stop/Restart of SAP NetWeaver Application Server
+- Start/Stop/Restart/Update of SAP Netweaver System
 - Multiple Automatic discovery and Start/Stop/Restart of SAP HANA Database Server or SAP NetWeaver Application Server
 
 ## Example execution
@@ -62,7 +63,7 @@ Assumptions for executing this role include:
 | :--- |:--- | :--- |
 | `SID` | SAP system SID | no, only if you are targetting a single SAP system|
 | `nowait` | Default: `false` | no, use only when absolutely sure! This will bypass all waiting and ignore all necessary steps for a graceful stop / start|
-| `sap_control_function` | Function to execute:<br/><ul><li>`restart_all_sap`</li><li>`restart_all_nw`</li><li>`restart_all_hana`</li><li>`restart_sap_nw`</li><li>`restart_sap_hana`</li><li>`stop_all_sap`</li><li>`start_all_sap`</li><li>`stop_all_nw`</li><li>`start_all_nw`</li><li>`stop_all_hana`</li><li>`start_all_hana`</li><li>`stop_sap_nw`</li><li>`start_sap_nw`</li><li>`stop_sap_hana`</li><li>`start_sap_hana`</li></ul> | yes, only this is required to detect the Instance Number which is used with SAP Host Agent `sapcontrol` CLI<br/><br/><br/>_Note: Executions using `all` will automatically detect any System IDs and corresponding Instance Numbers_ |
+| `sap_control_function` | Function to execute:<br/><ul><li>`restart_all_sap`</li><li>`restart_all_nw`</li><li>`restart_all_hana`</li><li>`restart_sap_nw`</li><li>`restart_sap_hana`</li><li>`stop_all_sap`</li><li>`start_all_sap`</li><li>`stop_all_nw`</li><li>`start_all_nw`</li><li>`stop_all_hana`</li><li>`start_all_hana`</li><li>`stop_sap_nw`</li><li>`start_sap_nw`</li><li>`stop_sap_hana`</li><li>`start_sap_hana`</li><li>`restartsystem_all_nw`</li><li>`updatesystem_all_nw`</li><li>`startsystem_all_nw`</li><li>`stopsystem_all_nw`</li></ul> | yes, only this is required to detect the Instance Number which is used with SAP Host Agent `sapcontrol` CLI<br/><br/><br/>_Note: Executions using `all` will automatically detect any System IDs and corresponding Instance Numbers_ |
 
 ## Ansible Role workflow and structure
 

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -50,6 +50,7 @@ sap_control_functions_list:
   - restartsystem_all_nw
   - updatesystem_all_nw
   - startsystem_all_nw
+  - stopsystem_all_nw
   - restart_all_sap
   - stop_all_sap
   - start_all_sap

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -3,21 +3,16 @@ sap_sid: "initial"
 sap_control_function: "initial"
 sap_control_name_header: "initial"
 
-sap_control_system_scope: "ALL"
-sap_control_system_waittimeout: 180
-sap_control_system_softtimeout: 480
-sap_control_system_force: 0
-
 nowait: false
 sap_control_start: "StartWait 180 2"
 sap_control_stop: "StopWait 180 2"
 
-sap_control_startsystem: "StartSystem {{ sap_control_system_scope }} {{ sap_control_system_waittimeout }}"
-sap_control_stopsystem: "StopSystem {{ sap_control_system_scope }} {{ sap_control_system_waittimeout }} {{ sap_control_system_softtimeout }}"
-sap_control_restartsystem: "RestartSystem {{ sap_control_system_scope }} {{ sap_control_system_waittimeout }} {{ sap_control_system_softtimeout }} {{ sap_control_system_runlevel }}"
-sap_control_updatesystem: "UpdateSystem {{ sap_control_system_waittimeout }} {{ sap_control_system_softtimeout }} {{ sap_control_system_force }}"
-sap_control_waitforstopped: "WaitforStopped {{ sap_control_system_waittimeout }} 2"
-sap_control_waitforstarted: "WaitforStarted {{ sap_control_system_waittimeout }} 2"
+sap_control_startsystem: "StartSystem ALL 180"  # function StartSystem waittimeout
+sap_control_stopsystem: "StopSystem ALL 180 480"  # function StopSystem waittimeout softtimeout
+sap_control_restartsystem: "RestartSystem ALL 180 480"  # function RestartSystem waittimeout softtimeout
+sap_control_updatesystem: "UpdateSystem 180 480 0"  # function UpdateSystem waittimeout softtimeout force
+sap_control_waitforstopped: "WaitforStopped 180 2"  # function WaitforStopped waittimeout delay
+sap_control_waitforstarted: "WaitforStarted 180 2"  # function WaitforStarted waittimeout delay
 
 # get_all_sap_sid_dir_nw: "/sapmnt"
 # get_all_sap_sid_dir_hana: "/hana/shared"

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -13,7 +13,7 @@ sap_control_updatesystem: "UpdateSystem 180 480 0"  # function UpdateSystem wait
 sap_control_waitforstopped: "WaitforStopped 180 2"  # function WaitforStopped waittimeout delay
 sap_control_waitforstarted: "WaitforStarted 180 2"  # function WaitforStarted waittimeout delay
 
-# Parameters to handle async functions
+# Parameters to handle async functions in sapcontrol_async.yml
 
 sap_control_startsystem_waitforasync:
   test_function: "GetSystemInstanceList"

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -14,6 +14,26 @@ sap_control_updatesystem: "UpdateSystem 180 480 0"  # function UpdateSystem wait
 sap_control_waitforstopped: "WaitforStopped 180 2"  # function WaitforStopped waittimeout delay
 sap_control_waitforstarted: "WaitforStarted 180 2"  # function WaitforStarted waittimeout delay
 
+sap_control_startsystem_waitforasync:
+  test_function: "{{ sap_control_waitforstarted }}"
+
+sap_control_stopsystem_waitforasync:
+  test_function: "{{ sap_control_waitforstopped }}"
+
+sap_control_restartsystem_waitforasync:
+  test_function: "GetSystemInstanceList"
+  retries: 60
+  delay: 10
+  until:
+    - test_function_result.stdout not in ['YELLOW', 'RED', 'GREY']
+
+sap_control_updatesystem_waitforasync:
+  test_function: "GetSystemUpdateList"
+  retries: 60
+  delay: 10
+  until:
+    - test_function_result.stdout not in ['YELLOW', 'RED', 'GREY']
+
 # get_all_sap_sid_dir_nw: "/sapmnt"
 # get_all_sap_sid_dir_hana: "/hana/shared"
 

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -3,9 +3,21 @@ sap_sid: "initial"
 sap_control_function: "initial"
 sap_control_name_header: "initial"
 
+sap_control_system_scope: "ALL"
+sap_control_system_waittimeout: 180
+sap_control_system_softtimeout: 480
+sap_control_system_force: 0
+
 nowait: false
 sap_control_start: "StartWait 180 2"
 sap_control_stop: "StopWait 180 2"
+
+sap_control_startsystem: "StartSystem {{ sap_control_system_scope }} {{ sap_control_system_waittimeout }}"
+sap_control_stopsystem: "StopSystem {{ sap_control_system_scope }} {{ sap_control_system_waittimeout }} {{ sap_control_system_softtimeout }}"
+sap_control_restartsystem: "RestartSystem {{ sap_control_system_scope }} {{ sap_control_system_waittimeout }} {{ sap_control_system_softtimeout }} {{ sap_control_system_runlevel }}"
+sap_control_updatesystem: "UpdateSystem {{ sap_control_system_waittimeout }} {{ sap_control_system_softtimeout }} {{ sap_control_system_force }}"
+sap_control_waitforstopped: "WaitforStopped {{ sap_control_system_waittimeout }} 2"
+sap_control_waitforstarted: "WaitforStarted {{ sap_control_system_waittimeout }} 2"
 
 # get_all_sap_sid_dir_nw: "/sapmnt"
 # get_all_sap_sid_dir_hana: "/hana/shared"
@@ -13,6 +25,8 @@ sap_control_stop: "StopWait 180 2"
 # Functions
 
 sap_control_functions_list:
+  - restartsystem_all_nw
+  - updatesystem_all_nw
   - restart_all_sap
   - stop_all_sap
   - start_all_sap
@@ -30,6 +44,16 @@ sap_control_functions_list:
   - start_sap_hana
 
 # Functions flow
+restartsystem_all_nw_list:
+  - sap_control_function_current: "nw_stopsystem"
+  - sap_control_function_current: "nw_waitforstopped"
+  - sap_control_function_current: "nw_startsystem"
+  - sap_control_function_current: "nw_waitforstarted"
+
+updatesystem_all_nw_list:
+  - sap_control_function_current: "nw_updatesystem"
+  - sap_control_function_current: "nw_waitforstarted"
+
 restart_all_sap_list:
   - sap_control_function_current: "nw_stop"
   - sap_control_function_current: "hana_stop"

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -76,6 +76,9 @@ restartsystem_all_nw_list:
 startsystem_all_nw_list:
   - sap_control_function_current: "nw_startsystem"
 
+stopsystem_all_nw_list:
+  - sap_control_function_current: "nw_stopsystem"
+
 updatesystem_all_nw_list:
   - sap_control_function_current: "nw_startsystem"
   - sap_control_function_current: "nw_updatesystem"

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -18,40 +18,28 @@ sap_control_startsystem_waitforasync:
   test_function: "GetSystemInstanceList"
   retries: 60
   delay: 10
-  until:
-    - not (test_function_result.stdout | regex_search('GRAY\s*$', multiline=True) or
-          test_function_result.stdout | regex_search('RED\s*$', multiline=True) or
-          test_function_result.stdout | regex_search('YELLOW\s*$', multiline=True))
-    - test_function_result.stdout | regex_search('GREEN\s*$', multiline=True)
+  until_false: 'GRAY\s*$|RED\s*$|YELLOW\s*$'
+  until_true: 'GREEN\s*$'
 
 sap_control_restartsystem_waitforasync:
   test_function: "GetSystemInstanceList"
   retries: 60
   delay: 10
-  until:
-    - not (test_function_result.stdout | regex_search('GRAY\s*$', multiline=True) or
-          test_function_result.stdout | regex_search('RED\s*$', multiline=True) or
-          test_function_result.stdout | regex_search('YELLOW\s*$', multiline=True))
-    - test_function_result.stdout | regex_search('GREEN\s*$', multiline=True)
+  until_false: 'GRAY\s*$|RED\s*$|YELLOW\s*$'
+  until_true: 'GREEN\s*$'
 
 sap_control_stopsystem_waitforasync:
   test_function: "GetSystemInstanceList"
   retries: 60
   delay: 10
-  until:
-    - not (test_function_result.stdout | regex_search('GREEN\s*$', multiline=True) or
-          test_function_result.stdout | regex_search('RED\s*$', multiline=True) or
-          test_function_result.stdout | regex_search('YELLOW\s*$', multiline=True))
-    - test_function_result.stdout | regex_search('GRAY\s*$', multiline=True)
+  until_false: 'GREEN\s*$|RED\s*$|YELLOW\s*$'
+  until_true: 'GRAY\s*$'
 
 sap_control_updatesystem_waitforasync:
   test_function: "GetSystemUpdateList"
   retries: 60
   delay: 10
-  until:
-    - not (test_function_result.stdout | regex_search('YELLOW\s*$', multiline=True) or
-          test_function_result.stdout | regex_search('RED\s*$', multiline=True) or
-          test_function_result.stdout | regex_search('GREY\s*$', multiline=True))
+  until_false: 'GRAY\s*$|RED\s*$|YELLOW\s*$|GREEN\s*$'
 
 # get_all_sap_sid_dir_nw: "/sapmnt"
 # get_all_sap_sid_dir_hana: "/hana/shared"

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -15,24 +15,35 @@ sap_control_waitforstopped: "WaitforStopped 180 2"  # function WaitforStopped wa
 sap_control_waitforstarted: "WaitforStarted 180 2"  # function WaitforStarted waittimeout delay
 
 sap_control_startsystem_waitforasync:
-  test_function: "{{ sap_control_waitforstarted }}"
-
-sap_control_stopsystem_waitforasync:
-  test_function: "{{ sap_control_waitforstopped }}"
-
-sap_control_restartsystem_waitforasync:
   test_function: "GetSystemInstanceList"
   retries: 60
   delay: 10
   until:
-    - test_function_result.stdout not in ['YELLOW', 'RED', 'GREY']
+    - not (test_function_result.stdout | regex_search('GRAY\s*$', multiline=True) or
+          test_function_result.stdout | regex_search('RED\s*$', multiline=True) or
+          test_function_result.stdout | regex_search('YELLOW\s*$', multiline=True))
+    - test_function_result.stdout | regex_search('GREEN\s*$', multiline=True)
+
+sap_control_restartsystem_waitforasync: "{{ sap_control_startsystem_waitforasync }}"
+
+sap_control_stopsystem_waitforasync:
+  test_function: "GetSystemInstanceList"
+  retries: 60
+  delay: 10
+  until:
+    - not (test_function_result.stdout | regex_search('GREEN\s*$', multiline=True) or
+          test_function_result.stdout | regex_search('RED\s*$', multiline=True) or
+          test_function_result.stdout | regex_search('YELLOW\s*$', multiline=True))
+    - test_function_result.stdout | regex_search('GRAY\s*$', multiline=True)
 
 sap_control_updatesystem_waitforasync:
   test_function: "GetSystemUpdateList"
   retries: 60
   delay: 10
   until:
-    - test_function_result.stdout not in ['YELLOW', 'RED', 'GREY']
+    - not (test_function_result.stdout | regex_search('YELLOW\s*$', multiline=True) or
+          test_function_result.stdout | regex_search('RED\s*$', multiline=True) or
+          test_function_result.stdout | regex_search('GREY\s*$', multiline=True))
 
 # get_all_sap_sid_dir_nw: "/sapmnt"
 # get_all_sap_sid_dir_hana: "/hana/shared"
@@ -42,6 +53,7 @@ sap_control_updatesystem_waitforasync:
 sap_control_functions_list:
   - restartsystem_all_nw
   - updatesystem_all_nw
+  - startsystem_all_nw
   - restart_all_sap
   - stop_all_sap
   - start_all_sap
@@ -58,18 +70,17 @@ sap_control_functions_list:
   - stop_sap_hana
   - start_sap_hana
 
+
 # Functions flow
 restartsystem_all_nw_list:
-  - sap_control_function_current: "nw_stopsystem"
-  - sap_control_function_current: "nw_waitforstopped"
+  - sap_control_function_current: "nw_restartsystem"
+
+startsystem_all_nw_list:
   - sap_control_function_current: "nw_startsystem"
-  - sap_control_function_current: "nw_waitforstarted"
 
 updatesystem_all_nw_list:
   - sap_control_function_current: "nw_startsystem"
-  - sap_control_function_current: "nw_waitforstarted"
   - sap_control_function_current: "nw_updatesystem"
-  - sap_control_function_current: "nw_waitforstarted"
 
 restart_all_sap_list:
   - sap_control_function_current: "nw_stop"

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -24,7 +24,15 @@ sap_control_startsystem_waitforasync:
           test_function_result.stdout | regex_search('YELLOW\s*$', multiline=True))
     - test_function_result.stdout | regex_search('GREEN\s*$', multiline=True)
 
-sap_control_restartsystem_waitforasync: "{{ sap_control_startsystem_waitforasync }}"
+sap_control_restartsystem_waitforasync:
+  test_function: "GetSystemInstanceList"
+  retries: 60
+  delay: 10
+  until:
+    - not (test_function_result.stdout | regex_search('GRAY\s*$', multiline=True) or
+          test_function_result.stdout | regex_search('RED\s*$', multiline=True) or
+          test_function_result.stdout | regex_search('YELLOW\s*$', multiline=True))
+    - test_function_result.stdout | regex_search('GREEN\s*$', multiline=True)
 
 sap_control_stopsystem_waitforasync:
   test_function: "GetSystemInstanceList"

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -6,13 +6,14 @@ sap_control_name_header: "initial"
 nowait: false
 sap_control_start: "StartWait 180 2"
 sap_control_stop: "StopWait 180 2"
-
 sap_control_startsystem: "StartSystem ALL 180"  # function StartSystem waittimeout
 sap_control_stopsystem: "StopSystem ALL 180 480"  # function StopSystem waittimeout softtimeout
 sap_control_restartsystem: "RestartSystem ALL 180 480"  # function RestartSystem waittimeout softtimeout
 sap_control_updatesystem: "UpdateSystem 180 480 0"  # function UpdateSystem waittimeout softtimeout force
 sap_control_waitforstopped: "WaitforStopped 180 2"  # function WaitforStopped waittimeout delay
 sap_control_waitforstarted: "WaitforStarted 180 2"  # function WaitforStarted waittimeout delay
+
+# Parameters to handle async functions
 
 sap_control_startsystem_waitforasync:
   test_function: "GetSystemInstanceList"

--- a/roles/sap_control/defaults/main.yml
+++ b/roles/sap_control/defaults/main.yml
@@ -46,6 +46,8 @@ restartsystem_all_nw_list:
   - sap_control_function_current: "nw_waitforstarted"
 
 updatesystem_all_nw_list:
+  - sap_control_function_current: "nw_startsystem"
+  - sap_control_function_current: "nw_waitforstarted"
   - sap_control_function_current: "nw_updatesystem"
   - sap_control_function_current: "nw_waitforstarted"
 

--- a/roles/sap_control/tasks/main.yml
+++ b/roles/sap_control/tasks/main.yml
@@ -104,10 +104,18 @@
   ansible.builtin.debug:
     msg:
       - "Starting sap_control with the following parameters: "
-      - "{{ sap_control_function }}"
-      - "{{ sap_control_start }}"
-      - "{{ sap_control_stop }}"
-      - "{{ nowait }}"
+      - "Function: {{ sap_control_function }}"
+      - "Standard commands:"
+      - "  Start: {{ sap_control_start }}"
+      - "  Stop: {{ sap_control_stop }}"
+      - "System commands (if applicable):"
+      - "  StartSystem: {{ sap_control_startsystem }}"
+      - "  StopSystem: {{ sap_control_stopsystem }}"
+      - "  RestartSystem: {{ sap_control_restartsystem }}"
+      - "  UpdateSystem: {{ sap_control_updatesystem }}"
+      - "  WaitforStopped: {{ sap_control_waitforstopped }}"
+      - "  WaitforStarted: {{ sap_control_waitforstarted }}"
+      - "NoWait: {{ nowait }}"
 
 # Start SAP Control
 - name: SAP Control

--- a/roles/sap_control/tasks/prepare.yml
+++ b/roles/sap_control/tasks/prepare.yml
@@ -9,7 +9,7 @@
   ansible.builtin.set_fact:
     sap_control_name_header: "{{ sap_type | upper }} {{ funct_type | capitalize }}"
 
-- name: SAP Control
+- name: SAP Control (not System wide functions)
   vars:
     sap_control_execute_sid: "{{ item.SID }}"
     sap_control_execute_type: "{{ item.Type }}"
@@ -19,3 +19,18 @@
   loop: "{{ sap_facts_register.ansible_facts.sap }}"
   when:
     - "item.InstanceType | lower == sap_type | lower"
+    - "not funct_type is match('.*system')"
+
+- name: SAP Control (System wide functions)
+  vars:
+    sap_control_execute_sid: "{{ item.SID }}"
+    sap_control_execute_type: "{{ item.Type }}"
+    sap_control_execute_instance_nr: "{{ item.NR }}"
+    sap_control_execute_instance_type: "{{ item.InstanceType }}"
+  ansible.builtin.include_tasks: "sapcontrol.yml"
+  loop: "{{ sap_facts_register.ansible_facts.sap }}"
+  when:
+    - "item.InstanceType | lower == sap_type | lower"
+    - "funct_type is match('.*system')"
+    - "item.TYPE | lower == 'ascs'
+      or item.TYPE | lower == 'scs'"

--- a/roles/sap_control/tasks/sapcontrol.yml
+++ b/roles/sap_control/tasks/sapcontrol.yml
@@ -12,9 +12,9 @@
   ansible.builtin.include_tasks: functions/sapstartsrv.yml
 
 # Execute sapcontrol
-- name: SAP {{ sap_control_name_header }} - Executing sapcontrol -nr {{ passed_sap_nr }} -function {{ vars['sap_control_' + funct_type] | regex_replace('\\{\\{([^\\}]+)\\}\\}', '\\1') | template }}
+- name: SAP {{ sap_control_name_header }} - Executing sapcontrol -nr {{ passed_sap_nr }} -function {{ vars['sap_control_' + funct_type] }}
   ansible.builtin.shell: |
-    source ~/.profile && sapcontrol -nr {{ passed_sap_nr }} -function {{ vars['sap_control_' + funct_type] | regex_replace('\\{\\{([^\\}]+)\\}\\}', '\\1') | template }}
+    source ~/.profile && sapcontrol -nr {{ passed_sap_nr }} -function {{ vars['sap_control_' + funct_type] }}
   args:
     executable: /bin/bash
   become: true

--- a/roles/sap_control/tasks/sapcontrol.yml
+++ b/roles/sap_control/tasks/sapcontrol.yml
@@ -22,10 +22,17 @@
   register: sapcontrol_status
   failed_when: "'FAIL' in sapcontrol_status.stdout"
 
+# Include sapcontrol async tasks
+- name: SAP {{ sap_control_name_header }} - Include async tasks
+  vars:
+    async_function_dict: "{{ vars['sap_control_' + funct_type + '_waitforasync'] }}"
+  ansible.builtin.include_tasks: sapcontrol_async.yml
+  when:
+    - funct_type is match('.*system')
+
 # Cleanipc
 - name: SAP {{ sap_control_name_header }} - Cleanipc
   ansible.builtin.include_tasks: functions/cleanipc.yml
   when:
     - "'nw' in sap_type"
     - "'stop' in funct_type"
-    - "not funct_type is match('.*system')"

--- a/roles/sap_control/tasks/sapcontrol.yml
+++ b/roles/sap_control/tasks/sapcontrol.yml
@@ -12,9 +12,9 @@
   ansible.builtin.include_tasks: functions/sapstartsrv.yml
 
 # Execute sapcontrol
-- name: SAP {{ sap_control_name_header }} - Executing sapcontrol -nr {{ passed_sap_nr }} -function {{ vars['sap_control_' + funct_type] }}
+- name: SAP {{ sap_control_name_header }} - Executing sapcontrol -nr {{ passed_sap_nr }} -function {{ vars['sap_control_' + funct_type] | regex_replace('\\{\\{([^\\}]+)\\}\\}', '\\1') | template }}
   ansible.builtin.shell: |
-    source ~/.profile && sapcontrol -nr {{ passed_sap_nr }} -function {{ vars['sap_control_' + funct_type] }}
+    source ~/.profile && sapcontrol -nr {{ passed_sap_nr }} -function {{ vars['sap_control_' + funct_type] | regex_replace('\\{\\{([^\\}]+)\\}\\}', '\\1') | template }}
   args:
     executable: /bin/bash
   become: true
@@ -28,3 +28,4 @@
   when:
     - "'nw' in sap_type"
     - "'stop' in funct_type"
+    - "not funct_type is match('.*system')"

--- a/roles/sap_control/tasks/sapcontrol_async.yml
+++ b/roles/sap_control/tasks/sapcontrol_async.yml
@@ -27,7 +27,3 @@
        Async function {{ async_function_dict.test_function }} for SAP SID {{ passed_sap_sid }}
        is done with result:
        {{ test_function_result.stdout }}
-
-- name: Fail
-  ansible.builtin.fail:
-    msg: "FAIL"

--- a/roles/sap_control/tasks/sapcontrol_async.yml
+++ b/roles/sap_control/tasks/sapcontrol_async.yml
@@ -6,11 +6,12 @@
     executable: /bin/bash
   become: true
   become_user: "{{ passed_sap_sid | lower }}adm"
-  register: sapcontrol_async_status
-#  failed_when: "'FAIL' in sapcontrol_async_status.stdout"
+  register: test_function_result
+#  failed_when: "'FAIL' in test_function_result.stdout"
   retries: "{{ async_function_dict.retries | default(0) | int }}"
   delay: "{{ async_function_dict.delay | default(0) | int }}"
   until: "{{ async_function_dict.until | default([]) }}"
+  # until: "{% for condition in async_function_dict.until_conditions %}{{ condition }}{% if not loop.last %} and {% endif %}{% endfor %}"
   failed_when: false
 
 - name: Debug stdout
@@ -18,7 +19,7 @@
     msg: |
        Async function {{ async_function_dict.test_function }} for SAP SID {{ passed_sap_sid }}
        is done with result:
-       {{ sapcontrol_async_status.stdout }}
+       {{ test_function_result.stdout }}
 
 - name: Fail
   ansible.builtin.fail:

--- a/roles/sap_control/tasks/sapcontrol_async.yml
+++ b/roles/sap_control/tasks/sapcontrol_async.yml
@@ -1,4 +1,8 @@
 ---
+- name: Pause for 5 Seconds
+  ansible.builtin.wait_for:
+    timeout: 5
+
 - name: SAP {{ sap_control_name_header }} - Checking if Async action is over by executing sapcontrol -nr {{ passed_sap_nr }} -function {{ async_function_dict.test_function }}
   ansible.builtin.shell: |
     source ~/.profile && sapcontrol -nr {{ passed_sap_nr }} -function {{ async_function_dict.test_function }}

--- a/roles/sap_control/tasks/sapcontrol_async.yml
+++ b/roles/sap_control/tasks/sapcontrol_async.yml
@@ -3,15 +3,6 @@
   ansible.builtin.wait_for:
     timeout: 5
 
-- name: Debug values
-  ansible.builtin.debug:
-    msg: |
-      Async function {{ async_function_dict.test_function }} for SAP SID {{ passed_sap_sid }}
-      with retries: {{ async_function_dict.retries | default(0) | int }}
-      and delay: {{ async_function_dict.delay | default(0) | int }}
-      and until conditions: {{ async_function_dict.until | default([]) }}
-      is being executed.
-
 - name: SAP {{ sap_control_name_header }} - Checking if Async action is over by executing sapcontrol -nr {{ passed_sap_nr }} -function {{ async_function_dict.test_function }}
   ansible.builtin.shell: |
     source ~/.profile && sapcontrol -nr {{ passed_sap_nr }} -function {{ async_function_dict.test_function }}
@@ -24,8 +15,10 @@
   retries: "{{ async_function_dict.retries | default(0) | int }}"
   delay: "{{ async_function_dict.delay | default(0) | int }}"
   until: >
-    (async_function_dict.until_false is defined and not test_function_result.stdout | regex_search(async_function_dict.until_false, multiline=True)) and
-    (async_function_dict.until_true is defined and test_function_result.stdout | regex_search(async_function_dict.until_true, multiline=True))
+    (async_function_dict.until_false is not defined
+    or async_function_dict.until_false is defined and not test_function_result.stdout | regex_search(async_function_dict.until_false, multiline=True)) and
+    (async_function_dict.until_true is not defined or
+    async_function_dict.until_true is defined and test_function_result.stdout | regex_search(async_function_dict.until_true, multiline=True))
   failed_when: false
 
 - name: Debug stdout

--- a/roles/sap_control/tasks/sapcontrol_async.yml
+++ b/roles/sap_control/tasks/sapcontrol_async.yml
@@ -23,8 +23,9 @@
 #  failed_when: "'FAIL' in test_function_result.stdout"
   retries: "{{ async_function_dict.retries | default(0) | int }}"
   delay: "{{ async_function_dict.delay | default(0) | int }}"
-  until: async_function_dict.until | default([])
-  # until: "{% for condition in async_function_dict.until_conditions %}{{ condition }}{% if not loop.last %} and {% endif %}{% endfor %}"
+  until: >
+    (async_function_dict.until_false is defined and not test_function_result.stdout | regex_search(async_function_dict.until_false, multiline=True)) and
+    (async_function_dict.until_true is defined and test_function_result.stdout | regex_search(async_function_dict.until_true, multiline=True))
   failed_when: false
 
 - name: Debug stdout

--- a/roles/sap_control/tasks/sapcontrol_async.yml
+++ b/roles/sap_control/tasks/sapcontrol_async.yml
@@ -3,6 +3,15 @@
   ansible.builtin.wait_for:
     timeout: 5
 
+- name: Debug values
+  ansible.builtin.debug:
+    msg: |
+      Async function {{ async_function_dict.test_function }} for SAP SID {{ passed_sap_sid }}
+      with retries: {{ async_function_dict.retries | default(0) | int }}
+      and delay: {{ async_function_dict.delay | default(0) | int }}
+      and until conditions: {{ async_function_dict.until | default([]) }}
+      is being executed.
+
 - name: SAP {{ sap_control_name_header }} - Checking if Async action is over by executing sapcontrol -nr {{ passed_sap_nr }} -function {{ async_function_dict.test_function }}
   ansible.builtin.shell: |
     source ~/.profile && sapcontrol -nr {{ passed_sap_nr }} -function {{ async_function_dict.test_function }}

--- a/roles/sap_control/tasks/sapcontrol_async.yml
+++ b/roles/sap_control/tasks/sapcontrol_async.yml
@@ -1,0 +1,25 @@
+---
+- name: SAP {{ sap_control_name_header }} - Checking if Async action is over by executing sapcontrol -nr {{ passed_sap_nr }} -function {{ async_function_dict.test_function }}
+  ansible.builtin.shell: |
+    source ~/.profile && sapcontrol -nr {{ passed_sap_nr }} -function {{ async_function_dict.test_function }}
+  args:
+    executable: /bin/bash
+  become: true
+  become_user: "{{ passed_sap_sid | lower }}adm"
+  register: sapcontrol_async_status
+#  failed_when: "'FAIL' in sapcontrol_async_status.stdout"
+  retries: "{{ async_function_dict.retries | default(0) | int }}"
+  delay: "{{ async_function_dict.delay | default(0) | int }}"
+  until: "{{ async_function_dict.until | default([]) }}"
+  failed_when: false
+
+- name: Debug stdout
+  ansible.builtin.debug:
+    msg: |
+       Async function {{ async_function_dict.test_function }} for SAP SID {{ passed_sap_sid }}
+       is done with result:
+       {{ sapcontrol_async_status.stdout }}
+
+- name: Fail
+  ansible.builtin.fail:
+    msg: "FAIL"

--- a/roles/sap_control/tasks/sapcontrol_async.yml
+++ b/roles/sap_control/tasks/sapcontrol_async.yml
@@ -10,7 +10,7 @@
 #  failed_when: "'FAIL' in test_function_result.stdout"
   retries: "{{ async_function_dict.retries | default(0) | int }}"
   delay: "{{ async_function_dict.delay | default(0) | int }}"
-  until: "{{ async_function_dict.until | default([]) }}"
+  until: async_function_dict.until | default([])
   # until: "{% for condition in async_function_dict.until_conditions %}{{ condition }}{% if not loop.last %} and {% endif %}{% endfor %}"
   failed_when: false
 


### PR DESCRIPTION
This PR adds support for SAP System-level functions (StartSystem, StopSystem, RestartSystem, and UpdateSystem) to the sap_control role. These functions operate across all instances of an SAP system rather than on individual components.

**Changes**

- (defaults/main.yml) Added new functions : 
```
restartsystem_all_nw
updatesystem_all_nw
startsystem_all_nw
stopsystem_all_nw
```
- (defaults/main.yml) Added new dictionary sap_control_<function>_waitforasync that provides the necessary elements for task file sapcontrol_async.yml to handle correctly the polling
- prepare.yml will now detect when the function name ends with `system` and include the according task file
- `system` function only run on the ASCS or SCS, ensuring that they'll run on each system in the limit but only once per system